### PR TITLE
fix #166: cannot find name 'null' in JSON.Null

### DIFF
--- a/assembly/JSON.ts
+++ b/assembly/JSON.ts
@@ -249,7 +249,7 @@ export class Null extends Value {
     return "null";
   }
 
-  valueOf(): null {
+  valueOf(): Null | null {
     return null;
   }
 }


### PR DESCRIPTION
Fix #166 