### PR TITLE
fix: null as return type causes compiler error

### DIFF
--- a/assembly/JSON.ts
+++ b/assembly/JSON.ts
@@ -260,10 +260,6 @@ export class Null extends Value {
   stringify(): string {
     return "null";
   }
-
-  valueOf(): null {
-    return null;
-  }
 }
 
 export class Bool extends Value {


### PR DESCRIPTION
When compiling the codebase, the following compiler error is thrown:
![image](https://user-images.githubusercontent.com/5522128/129765362-3e750355-cd3e-49c0-8de6-f4ad2c31327f.png)

We can resolve this compiler error by simply removing the `Null` class' `valueOf()` method, since `valueOf()` is not required by `Value`'s abstract interface.

This change does not seem to change the user facing interface at all. Usage as described in the README stays consistent.