### PR TITLE
Fixes compiler error

### DIFF
--- a/assembly/encoder.ts
+++ b/assembly/encoder.ts
@@ -79,7 +79,7 @@ export class JSONEncoder {
       this._isFirstKey[this._isFirstKey.length - 1] = 0;
     }
     if (str != null && (<string>str).length > 0) {
-      this.writeString(str!);
+      this.writeString(str);
       this.write(":");
     }
   }


### PR DESCRIPTION
I'm getting this error using asc `0.21.3`:

```
INFO AS210: Expression is never 'null'.
    :
 82 │ this.writeString(str!);
    │                  ~~~
    └─ in ~lib/assemblyscript-json/assembly/encoder.ts(82,24)
```

I believe it's because there is already a null check on the line above. This change fixed the problem for me.